### PR TITLE
Change yellow calculator buttons to blue

### DIFF
--- a/index.html
+++ b/index.html
@@ -56,7 +56,7 @@
   /* Цвета как в iPhone */
   .btn-gray { background-color: #a5a5a5; color: black; }
   .btn-dark { background-color: #333333; }
-  .btn-orange { background-color: #ff9f0a; }
+  .btn-orange { background-color: #007bff; }
 
   button:active {
     opacity: 0.6;


### PR DESCRIPTION
## Summary
- update the calculator's accent button color to blue to replace the previous yellow styling

## Testing
- no tests were run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68e50fe17524832f80b06a88885afa53