### PR TITLE
Refine navigation layout and hero card

### DIFF
--- a/index.html
+++ b/index.html
@@ -16,10 +16,6 @@
         <span class="brand-mark">A</span>
         <span class="brand-text">Aurora Atelier</span>
       </a>
-      <button class="nav-toggle" aria-label="Открыть меню" aria-expanded="false">
-        <span></span>
-        <span></span>
-      </button>
       <nav class="site-nav" aria-label="Основная навигация">
         <a href="#about">О нас</a>
         <a href="#services">Услуги</a>
@@ -196,24 +192,5 @@
     </div>
   </footer>
 
-  <script>
-    const navToggle = document.querySelector('.nav-toggle');
-    const siteNav = document.querySelector('.site-nav');
-
-    navToggle.addEventListener('click', () => {
-      const expanded = navToggle.getAttribute('aria-expanded') === 'true';
-      navToggle.setAttribute('aria-expanded', !expanded);
-      siteNav.classList.toggle('open');
-      document.body.classList.toggle('no-scroll');
-    });
-
-    siteNav.querySelectorAll('a').forEach(link => {
-      link.addEventListener('click', () => {
-        siteNav.classList.remove('open');
-        navToggle.setAttribute('aria-expanded', 'false');
-        document.body.classList.remove('no-scroll');
-      });
-    });
-  </script>
 </body>
 </html>

--- a/styles.css
+++ b/styles.css
@@ -29,10 +29,6 @@ body {
   line-height: 1.6;
 }
 
-body.no-scroll {
-  overflow: hidden;
-}
-
 img {
   max-width: 100%;
   display: block;
@@ -61,7 +57,7 @@ a {
 .nav-container {
   display: flex;
   align-items: center;
-  justify-content: space-between;
+  gap: 40px;
   min-height: 72px;
 }
 
@@ -87,59 +83,43 @@ a {
 }
 
 .site-nav {
-  position: fixed;
-  inset: 0;
-  background: rgba(5, 3, 12, 0.94);
   display: flex;
-  flex-direction: column;
   align-items: center;
-  justify-content: center;
-  gap: 32px;
-  transform: translateY(-100%);
-  opacity: 0;
-  visibility: hidden;
-  pointer-events: none;
-  transition: transform 0.4s ease, opacity 0.4s ease;
-  font-size: 1.25rem;
-}
-
-.site-nav.open {
-  transform: translateY(0);
-  opacity: 1;
-  visibility: visible;
-  pointer-events: auto;
+  gap: 20px;
+  margin-left: auto;
+  flex-wrap: wrap;
 }
 
 .site-nav a {
-  color: var(--color-text);
-  padding: 12px 24px;
-  border-radius: 999px;
-  transition: background 0.3s ease, color 0.3s ease;
+  color: var(--color-muted);
+  font-weight: 500;
+  letter-spacing: 0.04em;
+  padding: 10px 0;
+  position: relative;
+  transition: color 0.3s ease;
+}
+
+.site-nav a::after {
+  content: "";
+  position: absolute;
+  left: 0;
+  bottom: 0;
+  width: 100%;
+  height: 2px;
+  background: linear-gradient(135deg, rgba(179, 140, 255, 0.8), rgba(113, 231, 255, 0.6));
+  transform: scaleX(0);
+  transform-origin: left;
+  transition: transform 0.3s ease;
 }
 
 .site-nav a:hover,
 .site-nav a:focus-visible {
-  background: rgba(179, 140, 255, 0.08);
-  color: #fff;
+  color: var(--color-text);
 }
 
-.nav-toggle {
-  display: grid;
-  gap: 6px;
-  width: 44px;
-  height: 44px;
-  border-radius: 14px;
-  border: 1px solid var(--color-line);
-  background: rgba(255, 255, 255, 0.02);
-  padding: 10px;
-  cursor: pointer;
-}
-
-.nav-toggle span {
-  display: block;
-  height: 2px;
-  background: var(--color-text);
-  border-radius: 2px;
+.site-nav a:hover::after,
+.site-nav a:focus-visible::after {
+  transform: scaleX(1);
 }
 
 .hero {
@@ -232,11 +212,18 @@ a {
 
 .hero-card {
   position: relative;
-  padding: 32px;
-  border-radius: 28px;
-  background: rgba(12, 8, 24, 0.8);
-  border: 1px solid rgba(179, 140, 255, 0.18);
+  padding: 28px;
+  border-radius: 24px;
+  background: rgba(12, 8, 24, 0.82);
+  border: 1px solid rgba(179, 140, 255, 0.22);
   box-shadow: var(--shadow-card);
+  max-width: 360px;
+  width: 100%;
+}
+
+.card-inner {
+  display: grid;
+  gap: 18px;
 }
 
 .card-glow {
@@ -256,14 +243,18 @@ a {
 }
 
 .card-copy {
-  margin: 18px 0 24px;
+  margin: 0;
   color: #e6e1f4;
 }
 
 .card-divider {
   height: 1px;
   background: var(--color-line);
-  margin-bottom: 18px;
+}
+
+.card-signature {
+  display: grid;
+  gap: 4px;
 }
 
 .card-signature span {
@@ -547,22 +538,6 @@ a {
 }
 
 @media (min-width: 900px) {
-  .site-nav {
-    position: static;
-    transform: none;
-    background: transparent;
-    flex-direction: row;
-    gap: 28px;
-    font-size: 1rem;
-    opacity: 1;
-    visibility: visible;
-    pointer-events: auto;
-  }
-
-  .nav-toggle {
-    display: none;
-  }
-
   .hero-content {
     grid-template-columns: 1.2fr 0.8fr;
     align-items: center;
@@ -573,6 +548,7 @@ a {
   }
 
   .hero-card {
-    align-self: stretch;
+    align-self: center;
+    justify-self: end;
   }
 }


### PR DESCRIPTION
## Summary
- replace the mobile overlay navigation with a persistent horizontal menu for consistent presentation
- tighten the hero card styling so the content appears more compact and balanced

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e520d8ade0832f97b0614cd0ebb1f0