### PR TITLE
Добавить отступы и скругления в reception-gallery

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -564,13 +564,18 @@ body.nav-open .nav-overlay {
 }
 
 .reception-gallery__list {
-  margin: 0;
+  width: min(100%, 1240px);
+  margin: 0 auto;
+  padding: clamp(24px, 4vw, 48px) 20px;
+  display: grid;
+  gap: clamp(16px, 3vw, 32px);
 }
 
 .reception-gallery__list img {
   display: block;
   width: 100%;
   height: auto;
+  border-radius: clamp(16px, 2.6vw, 28px);
 }
 
 .industries-layout {


### PR DESCRIPTION
### Motivation
- Привести страницу `reception-gallery.html` к той же ширине/отступам, что и основная страница, и улучшить визуальную читаемость галереи за счёт отступов между изображениями и скругления углов.

### Description
- Обновлён `styles.css` для `.reception-gallery__list`: задана ширина `width: min(100%, 1240px)`, центровка через `margin: 0 auto` и внутренние отступы `padding: clamp(24px, 4vw, 48px) 20px`.
- Галерея теперь использует CSS grid через `display: grid` и расстояние между элементами `gap: clamp(16px, 3vw, 32px)`.
- У изображений галереи добавлено скругление углов `border-radius: clamp(16px, 2.6vw, 28px)`.

### Testing
- Запущен локальный статический сервер с `python -m http.server 8000` и выполнён Playwright-скрипт, который открыл `http://127.0.0.1:8000/reception-gallery.html` и сделал скриншот, скрипт успешно завершился и сохранил `artifacts/reception-gallery.png`.
- Изменения зафиксированы в репозитории через `git commit` и файл `styles.css` находится в рабочей ветке.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69838fc4a100832fbd1d16e0cef65609)