### PR TITLE
Default to dark theme and replace theme button with slider control

### DIFF
--- a/index.html
+++ b/index.html
@@ -37,8 +37,13 @@
         <a href="#team">Команда</a>
         <a href="#contact">Контакты</a>
       </nav>
-      <button class="theme-toggle" type="button" aria-label="Переключить тему" aria-pressed="false">
-        <span class="theme-toggle__label">Светлая</span>
+      <button class="theme-toggle" type="button" aria-label="Переключить на светлую тему" aria-pressed="true">
+        <span class="theme-toggle__track" aria-hidden="true">
+          <span class="theme-toggle__thumb">
+            <span class="theme-toggle__icon theme-toggle__icon--sun">☀</span>
+            <span class="theme-toggle__icon theme-toggle__icon--moon">☾</span>
+          </span>
+        </span>
       </button>
     </div>
     <div class="nav-overlay" hidden aria-hidden="true"></div>

--- a/mini-app.html
+++ b/mini-app.html
@@ -29,8 +29,13 @@
         <a href="index.html#team">Команда</a>
         <a href="index.html#contact">Контакты</a>
       </nav>
-      <button class="theme-toggle" type="button" aria-label="Переключить тему" aria-pressed="false">
-        <span class="theme-toggle__label">Светлая</span>
+      <button class="theme-toggle" type="button" aria-label="Переключить на светлую тему" aria-pressed="true">
+        <span class="theme-toggle__track" aria-hidden="true">
+          <span class="theme-toggle__thumb">
+            <span class="theme-toggle__icon theme-toggle__icon--sun">☀</span>
+            <span class="theme-toggle__icon theme-toggle__icon--moon">☾</span>
+          </span>
+        </span>
       </button>
       <div class="nav-overlay" aria-hidden="true"></div>
     </div>

--- a/site-ui.js
+++ b/site-ui.js
@@ -1,6 +1,6 @@
 (function () {
   const THEME_KEY = 'nf-theme';
-  const DEFAULT_THEME = 'light';
+  const DEFAULT_THEME = 'dark';
 
   const getStoredTheme = () => {
     try {
@@ -28,10 +28,7 @@
       button.setAttribute('aria-pressed', String(isDark));
       button.setAttribute('aria-label', isDark ? 'Переключить на светлую тему' : 'Переключить на тёмную тему');
 
-      const label = button.querySelector('.theme-toggle__label');
-      if (label) {
-        label.textContent = isDark ? 'Тёмная' : 'Светлая';
-      }
+      button.classList.toggle('is-dark', isDark);
     });
   };
 

--- a/styles.css
+++ b/styles.css
@@ -192,32 +192,105 @@ a {
 .theme-toggle {
   display: inline-flex;
   align-items: center;
-  justify-content: center;
-  min-width: 122px;
+  justify-content: flex-start;
+  width: 120px;
   height: 44px;
-  padding: 0 14px;
-  border-radius: 12px;
-  border: 1px solid var(--menu-btn-border);
-  background: var(--menu-btn-bg);
-  color: var(--color-text);
-  font: inherit;
-  font-size: 0.9rem;
-  font-weight: 600;
+  padding: 4px;
+  border-radius: 999px;
+  border: 1px solid rgba(84, 93, 128, 0.18);
+  background: #4c5470;
   cursor: pointer;
-  transition: background 0.25s ease, border-color 0.25s ease, transform 0.25s ease;
+  transition: background 0.25s ease, border-color 0.25s ease;
   position: relative;
   z-index: 1201;
 }
 
-.theme-toggle:hover {
-  background: var(--menu-btn-hover-bg);
-  border-color: var(--menu-btn-border);
-  transform: translateY(-1px);
+.theme-toggle__track {
+  width: 100%;
+  height: 100%;
+  border-radius: inherit;
+  position: relative;
+}
+
+.theme-toggle__thumb {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 36px;
+  height: 36px;
+  border-radius: 50%;
+  background: #131825;
+  box-shadow: 0 8px 18px rgba(2, 4, 10, 0.32);
+  display: grid;
+  place-items: center;
+  transform: translateX(0);
+  transition: transform 0.25s ease, background 0.25s ease, box-shadow 0.25s ease;
+}
+
+.theme-toggle__icon {
+  grid-area: 1 / 1;
+  font-size: 1.65rem;
+  line-height: 1;
+  transition: opacity 0.2s ease, transform 0.2s ease;
+}
+
+.theme-toggle__icon--sun {
+  opacity: 0;
+  transform: scale(0.8);
+  color: #f5ca23;
+}
+
+.theme-toggle__icon--moon {
+  opacity: 1;
+  transform: scale(1);
+  color: #eef2f9;
+}
+
+.theme-toggle[aria-pressed="false"] {
+  background: #c0c7dc;
+  border-color: rgba(86, 97, 132, 0.2);
+}
+
+.theme-toggle[aria-pressed="false"] .theme-toggle__thumb {
+  transform: translateX(76px);
+  background: #f2f5fc;
+  box-shadow: 0 8px 18px rgba(90, 103, 143, 0.22);
+}
+
+.theme-toggle[aria-pressed="false"] .theme-toggle__icon--sun {
+  opacity: 1;
+  transform: scale(1);
+}
+
+.theme-toggle[aria-pressed="false"] .theme-toggle__icon--moon {
+  opacity: 0;
+  transform: scale(0.8);
 }
 
 .theme-toggle:focus-visible {
   outline: 2px solid var(--color-accent);
   outline-offset: 2px;
+}
+
+:root:not([data-theme="dark"]) .btn,
+:root:not([data-theme="dark"]) .btn.primary,
+:root:not([data-theme="dark"]) .btn.secondary,
+:root:not([data-theme="dark"]) .btn.ghost,
+:root:not([data-theme="dark"]) .btn.cta-btn {
+  background: var(--header-bg);
+  border-color: var(--header-border);
+  color: var(--color-text);
+  box-shadow: none;
+}
+
+:root:not([data-theme="dark"]) .btn:hover,
+:root:not([data-theme="dark"]) .btn.primary:hover,
+:root:not([data-theme="dark"]) .btn.secondary:hover,
+:root:not([data-theme="dark"]) .btn.ghost:hover,
+:root:not([data-theme="dark"]) .btn.cta-btn:hover {
+  background: var(--header-bg);
+  box-shadow: none;
+  transform: none;
 }
 
 .menu-bar {

--- a/telegram-platform.html
+++ b/telegram-platform.html
@@ -636,8 +636,13 @@
         <a href="index.html#team">Команда</a>
         <a href="index.html#contact">Контакты</a>
       </nav>
-      <button class="theme-toggle" type="button" aria-label="Переключить тему" aria-pressed="false">
-        <span class="theme-toggle__label">Светлая</span>
+      <button class="theme-toggle" type="button" aria-label="Переключить на светлую тему" aria-pressed="true">
+        <span class="theme-toggle__track" aria-hidden="true">
+          <span class="theme-toggle__thumb">
+            <span class="theme-toggle__icon theme-toggle__icon--sun">☀</span>
+            <span class="theme-toggle__icon theme-toggle__icon--moon">☾</span>
+          </span>
+        </span>
       </button>
       <div class="nav-overlay" aria-hidden="true"></div>
     </div>

--- a/telegram-shops.html
+++ b/telegram-shops.html
@@ -489,8 +489,13 @@
         <a href="index.html#team">Команда</a>
         <a href="index.html#contact">Контакты</a>
       </nav>
-      <button class="theme-toggle" type="button" aria-label="Переключить тему" aria-pressed="false">
-        <span class="theme-toggle__label">Светлая</span>
+      <button class="theme-toggle" type="button" aria-label="Переключить на светлую тему" aria-pressed="true">
+        <span class="theme-toggle__track" aria-hidden="true">
+          <span class="theme-toggle__thumb">
+            <span class="theme-toggle__icon theme-toggle__icon--sun">☀</span>
+            <span class="theme-toggle__icon theme-toggle__icon--moon">☾</span>
+          </span>
+        </span>
       </button>
       <div class="nav-overlay" aria-hidden="true"></div>
     </div>

--- a/telegram-store.html
+++ b/telegram-store.html
@@ -740,8 +740,13 @@
         <a href="index.html#team">Команда</a>
         <a href="index.html#contact">Контакты</a>
       </nav>
-      <button class="theme-toggle" type="button" aria-label="Переключить тему" aria-pressed="false">
-        <span class="theme-toggle__label">Светлая</span>
+      <button class="theme-toggle" type="button" aria-label="Переключить на светлую тему" aria-pressed="true">
+        <span class="theme-toggle__track" aria-hidden="true">
+          <span class="theme-toggle__thumb">
+            <span class="theme-toggle__icon theme-toggle__icon--sun">☀</span>
+            <span class="theme-toggle__icon theme-toggle__icon--moon">☾</span>
+          </span>
+        </span>
       </button>
     </div>
     <div class="nav-overlay" hidden aria-hidden="true"></div>

--- a/text-agents.html
+++ b/text-agents.html
@@ -29,8 +29,13 @@
         <a href="index.html#team">Команда</a>
         <a href="index.html#contact">Контакты</a>
       </nav>
-      <button class="theme-toggle" type="button" aria-label="Переключить тему" aria-pressed="false">
-        <span class="theme-toggle__label">Светлая</span>
+      <button class="theme-toggle" type="button" aria-label="Переключить на светлую тему" aria-pressed="true">
+        <span class="theme-toggle__track" aria-hidden="true">
+          <span class="theme-toggle__thumb">
+            <span class="theme-toggle__icon theme-toggle__icon--sun">☀</span>
+            <span class="theme-toggle__icon theme-toggle__icon--moon">☾</span>
+          </span>
+        </span>
       </button>
       <div class="nav-overlay" aria-hidden="true"></div>
     </div>

--- a/voice-agents.html
+++ b/voice-agents.html
@@ -35,8 +35,13 @@
         <a href="index.html#team">Команда</a>
         <a href="index.html#contact">Контакты</a>
       </nav>
-      <button class="theme-toggle" type="button" aria-label="Переключить тему" aria-pressed="false">
-        <span class="theme-toggle__label">Светлая</span>
+      <button class="theme-toggle" type="button" aria-label="Переключить на светлую тему" aria-pressed="true">
+        <span class="theme-toggle__track" aria-hidden="true">
+          <span class="theme-toggle__thumb">
+            <span class="theme-toggle__icon theme-toggle__icon--sun">☀</span>
+            <span class="theme-toggle__icon theme-toggle__icon--moon">☾</span>
+          </span>
+        </span>
       </button>
       <div class="nav-overlay" aria-hidden="true"></div>
     </div>


### PR DESCRIPTION
### Motivation
- Сделать тёмную тему активной по умолчанию для единообразного начального вида сайта.
- Заменить текстовую кнопку переключения темы на визуально знакомый ползунок (трек + кружок, иконки солнца/луны) для удобства и соответствия референсу.
- На светлой теме убрать яркие акценты у кнопок и сделать их фон таким же спокойным, как у панели навигации, чтобы не было выделений.

### Description
- Установил `DEFAULT_THEME = 'dark'` и обновил логику в `applyTheme` в `site-ui.js`, теперь переключатель выставляет `aria-pressed` и добавляет/убирает класс `is-dark` для элементов `.theme-toggle`.
- Заменил разметку текстовой кнопки темы на slider-версию (`.theme-toggle__track` / `.theme-toggle__thumb` / иконки) во всех страницах с хедером: `index.html`, `mini-app.html`, `text-agents.html`, `voice-agents.html`, `telegram-platform.html`, `telegram-shops.html`, `telegram-store.html`.
- Добавил стили для ползунка и состояний в `styles.css` (`.theme-toggle`, `.theme-toggle__track`, `.theme-toggle__thumb`, `.theme-toggle__icon`, состояние по `aria-pressed`) и добавил правила для светлой темы, которые выравнивают фон кнопок (`.btn*`) с `var(--header-bg)` и убирают тени/hover-подъём.

### Testing
- Выполнена проверка синтаксиса скрипта командой `node --check site-ui.js`, результат: успешно.
- Выполнен поиск по файлам через `rg` для подтверждения новой разметки `theme-toggle`/`theme-toggle__track`, результат: все целевые файлы обновлены.
- Изменения зафиксированы в репозитории (commit прошёл успешно, затронуто 9 файлов).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e4c461b1a4832fab28e38dd49caf1a)