### PR TITLE
Compact theme toggle and improved light‑theme contrast

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -193,8 +193,8 @@ a {
   display: inline-flex;
   align-items: center;
   justify-content: flex-start;
-  width: 120px;
-  height: 44px;
+  width: 102px;
+  height: 38px;
   padding: 4px;
   border-radius: 999px;
   border: 1px solid rgba(84, 93, 128, 0.18);
@@ -216,8 +216,8 @@ a {
   position: absolute;
   top: 0;
   left: 0;
-  width: 36px;
-  height: 36px;
+  width: 30px;
+  height: 30px;
   border-radius: 50%;
   background: #131825;
   box-shadow: 0 8px 18px rgba(2, 4, 10, 0.32);
@@ -229,7 +229,7 @@ a {
 
 .theme-toggle__icon {
   grid-area: 1 / 1;
-  font-size: 1.65rem;
+  font-size: 1.35rem;
   line-height: 1;
   transition: opacity 0.2s ease, transform 0.2s ease;
 }
@@ -243,7 +243,14 @@ a {
 .theme-toggle__icon--moon {
   opacity: 1;
   transform: scale(1);
-  color: #eef2f9;
+  width: 16px;
+  height: 16px;
+  font-size: 0;
+  color: transparent;
+  background-image: url("data:image/svg+xml,%3Csvg fill='none' viewBox='0 0 20 20' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath fill-rule='evenodd' clip-rule='evenodd' d='M4.16009 10.5658C3.83884 10.3793 3.40306 10.6104 3.4808 10.9737C4.12474 13.9824 6.79881 16.2384 9.9998 16.2384C13.6817 16.2384 16.6665 13.2536 16.6665 9.5717C16.6665 6.37071 14.4105 3.69664 11.4018 3.0527C11.0385 2.97496 10.8074 3.41073 10.9939 3.73199C11.4216 4.46886 11.6665 5.32501 11.6665 6.23836C11.6665 8.99979 9.42789 11.2384 6.66647 11.2384C5.75311 11.2384 4.89696 10.9935 4.16009 10.5658Z' fill='%23EDEEF0'/%3E%3C/svg%3E");
+  background-repeat: no-repeat;
+  background-position: center;
+  background-size: contain;
 }
 
 .theme-toggle[aria-pressed="false"] {
@@ -252,7 +259,7 @@ a {
 }
 
 .theme-toggle[aria-pressed="false"] .theme-toggle__thumb {
-  transform: translateX(76px);
+  transform: translateX(64px);
   background: #f2f5fc;
   box-shadow: 0 8px 18px rgba(90, 103, 143, 0.22);
 }
@@ -291,6 +298,15 @@ a {
   background: var(--header-bg);
   box-shadow: none;
   transform: none;
+}
+
+:root:not([data-theme="dark"]) .mini-app-eyebrow,
+:root:not([data-theme="dark"]) .solutions .section-head .section-kicker,
+:root:not([data-theme="dark"]) .solutions .service-card .link-btn,
+:root:not([data-theme="dark"]) .mini-app-accordion__item--active .mini-app-accordion__icon,
+:root:not([data-theme="dark"]) .process-step__subtitle,
+:root:not([data-theme="dark"]) .faq-item summary svg {
+  color: #5a3fd6;
 }
 
 .menu-bar {
@@ -2309,9 +2325,9 @@ body.nav-open .menu-bar:nth-child(3) {
 
   .theme-toggle {
     display: inline-flex;
-    min-width: 108px;
-    height: 44px;
-    padding: 0 12px;
+    min-width: 102px;
+    height: 38px;
+    padding: 4px;
     font-size: 0.86rem;
   }
 


### PR DESCRIPTION
### Motivation
- Сделать переключатель темы компактнее и аккуратнее на десктопе и мобильных ширинах. 
- Улучшить читаемость светлой темы, заменив бледно‑розовые акценты на более контрастный цвет, чтобы текст и иконки не сливались с фоном.

### Description
- Изменены размеры переключателя и его элементов в `styles.css`: `width`/`height` переключателя на `102x38`, размер ползунка на `30x30`, икона уменьшена (`font-size: 1.35rem`) и смещение в светлой теме подогнано (`transform: translateX(64px)`).
- Для ночной темы иконка луны заменена на предоставленный SVG, встроенный как `data:image/svg+xml` в правило `.theme-toggle__icon--moon` для точного соответствия референсу.
- Добавлены правила для светлой темы (`:root:not([data-theme="dark"])`) которые заменяют ряд бледно‑розовых акцентов на более контрастный `#5a3fd6` для селекторов вроде `.mini-app-eyebrow`, `.solutions .section-head .section-kicker`, `.process-step__subtitle`, и других.
- Применены те же компактные размеры переключателя в мобильном медиазапросе (`min-width: 102px; height: 38px; padding: 4px`).

### Testing
- Запущена проверка на пробельные/синтаксические проблемы с `git diff --check` и она прошла без замечаний. 
- Проверен статус изменений через `git status --short` и файл `styles.css` отражает ожидаемые изменения. 
- Нет автоматических визуальных тестов в этой среде, поэтому визуальная проверка требуется в браузере после деплоя.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e4c6ba1488832f993c0c5ce845cf7e)